### PR TITLE
Removed pre-battle countdown and re-added local keybind hints

### DIFF
--- a/RoundsWithFriends/GameModes/RWFGameMode.cs
+++ b/RoundsWithFriends/GameModes/RWFGameMode.cs
@@ -361,6 +361,7 @@ namespace RWF.GameModes
 
             yield return this.SyncBattleStart();
 
+            /*
             for (int i = 3; i >= 1; i--)
             {
                 UIHandler.instance.DisplayRoundStartText($"{i}");
@@ -368,8 +369,9 @@ namespace RWF.GameModes
                 yield return new WaitForSecondsRealtime(0.5f);
             }
 
-            SoundManager.Instance.Play(PointVisualizer.instance.sound_UI_Arms_Race_C_Ball_Pop_Shake, this.transform);
             UIHandler.instance.DisplayRoundStartText("FIGHT");
+            */
+            SoundManager.Instance.Play(PointVisualizer.instance.sound_UI_Arms_Race_C_Ball_Pop_Shake, this.transform);
             PlayerManager.instance.SetPlayersSimulated(true);
 
             yield return GameModeManager.TriggerHook(GameModeHooks.HookBattleStart);
@@ -397,6 +399,7 @@ namespace RWF.GameModes
 
             yield return this.SyncBattleStart();
 
+            /*
             for (int i = 3; i >= 1; i--)
             {
                 UIHandler.instance.DisplayRoundStartText($"{i}");
@@ -404,8 +407,9 @@ namespace RWF.GameModes
                 yield return new WaitForSecondsRealtime(0.5f);
             }
 
-            SoundManager.Instance.Play(PointVisualizer.instance.sound_UI_Arms_Race_C_Ball_Pop_Shake, this.transform);
             UIHandler.instance.DisplayRoundStartText("FIGHT");
+            */
+            SoundManager.Instance.Play(PointVisualizer.instance.sound_UI_Arms_Race_C_Ball_Pop_Shake, this.transform);
             PlayerManager.instance.SetPlayersSimulated(true);
 
             yield return GameModeManager.TriggerHook(GameModeHooks.HookBattleStart);

--- a/RoundsWithFriends/RoundsWithFriends.cs
+++ b/RoundsWithFriends/RoundsWithFriends.cs
@@ -460,6 +460,8 @@ namespace RWF
             var mainMenuGo = uiGo.transform.Find("UI_MainMenu").Find("Canvas").gameObject;
             var charSelectionGroupGo = mainMenuGo.transform.Find("ListSelector").Find("CharacterSelect").GetChild(0).gameObject;
 
+            StartCoroutine(InjectKeybindsWhenReady());
+
             if (!charSelectionGroupGo.transform.Find("CharacterSelect 3"))
             {
                 var charSelectInstanceGo1 = charSelectionGroupGo.transform.GetChild(0).gameObject;
@@ -541,6 +543,30 @@ namespace RWF
                 popupGo.transform.localScale = Vector3.one;
                 popupGo.AddComponent<UI.PopUpMenu>();
             }
+
+        }
+        public IEnumerator InjectKeybindsWhenReady()
+        {
+            var uiGo = GameObject.Find("/Game/UI");
+            var mainMenuGo = uiGo.transform.Find("UI_MainMenu").Find("Canvas").gameObject;
+            
+            var localGameModeGroupGo = mainMenuGo.transform.Find("ListSelector/LOCAL/Group/Grid/Scroll View/Viewport/Content")?.gameObject;
+            while (localGameModeGroupGo is null)
+            {
+                yield return new WaitForEndOfFrame();
+                localGameModeGroupGo = mainMenuGo.transform.Find("ListSelector/LOCAL/Group/Grid/Scroll View/Viewport/Content")?.gameObject;
+            }
+            foreach (Transform gameModeButtonGo in localGameModeGroupGo.transform)
+            {
+                if (gameModeButtonGo.name == "Test") { continue; } // we don't want to add keybind hints to Sandbox
+                var gameModeButton = gameModeButtonGo.GetComponent<Button>();
+                if (gameModeButton is null) { continue; }
+                gameModeButton.onClick.AddListener(() =>
+                {
+                    KeybindHints.CreateLocalHints();
+                });
+            }                    
+            yield break; 
         }
     }
 }


### PR DESCRIPTION
- Pre-battle countdown _should_ have been unnecessary since RWEMF update. It is also bad for balancing (heavily favors aggro builds)
- Local menu keybind hints were removed and never re-added, making the local match screen appear entirely blank.