### PR TITLE
Fix extra cards not showing in bar

### DIFF
--- a/RoundsWithFriends/Patches/CardBar.cs
+++ b/RoundsWithFriends/Patches/CardBar.cs
@@ -1,0 +1,16 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace RWF.Patches
+{
+    [HarmonyPatch(typeof(CardBar), "Start")]
+    class CardBar_Patch_Start
+    {
+        static void Postfix(CardBar __instance)
+        {
+            // expand the bar to make room for more card buttons
+            var rect = __instance.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0, 1);
+        }
+    }
+}


### PR DESCRIPTION
Makes the card bar in the top right wider so cards aren't cut off